### PR TITLE
移除代码里不存在的默认配置项

### DIFF
--- a/src/main/resources/Languages/English/RewardSettings-NEWVERSION.yml
+++ b/src/main/resources/Languages/English/RewardSettings-NEWVERSION.yml
@@ -205,7 +205,6 @@ Reward-Settings:
                 Disabled-Modules:
                     Special-Dates: true
                     Special-Weeks: true
-                    Special-Times: true
                     Statistics-Times: false
                     Statistics-Times-Cycle: false
                 Reward-Items:

--- a/src/main/resources/Languages/Japanese/RewardSettings-NEWVERSION.yml
+++ b/src/main/resources/Languages/Japanese/RewardSettings-NEWVERSION.yml
@@ -208,7 +208,6 @@ Reward-Settings:
                 Disabled-Modules:
                     Special-Dates: true
                     Special-Weeks: true
-                    Special-Times: true
                     Statistics-Times: false
                     Statistics-Times-Cycle: false
                 Reward-Items:

--- a/src/main/resources/Languages/Simplified-Chinese/RewardSettings-NEWVERSION.yml
+++ b/src/main/resources/Languages/Simplified-Chinese/RewardSettings-NEWVERSION.yml
@@ -215,7 +215,6 @@ Reward-Settings:
                 Disabled-Modules:
                     Special-Dates: true
                     Special-Weeks: true
-                    Special-Times: true
                     Statistics-Times: false
                     Statistics-Times-Cycle: false
                 Reward-Items:

--- a/src/main/resources/Languages/Traditional-Chinese/RewardSettings-NEWVERSION.yml
+++ b/src/main/resources/Languages/Traditional-Chinese/RewardSettings-NEWVERSION.yml
@@ -214,7 +214,6 @@ Reward-Settings:
                 Disabled-Modules:
                     Special-Dates: true
                     Special-Weeks: true
-                    Special-Times: true
                     Statistics-Times: false
                     Statistics-Times-Cycle: false
                 Reward-Items:


### PR DESCRIPTION
代码里并没有实现 RewardSettings.yml 的Reward-Settings.Permission-Groups.Default.Retroactive-Time.Disabled-Modules.Special-Times 项，应从默认 RewardSettings 里移除，避免误导使用者